### PR TITLE
Update to newton-usd-schemas 0.3.1 and lock mujoco to 3.8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Unreleased
+
+## Features
+
+- Apply `NewtonSiteAPI` on site prims alongside `MjcSiteAPI`
+- Apply `NewtonMassAPI` with `newton:massModel = "shell"` on collision geoms with shell inertia
+- Author `newton:inertia` compact tensor on bodies with full inertia matrices
+- Author `newton:contactStiffness` and `newton:contactDamping` on physics materials (computed from MuJoCo solref)
+
+## Dependencies
+
+- Updated to `newton-usd-schemas>=0.3.1`
+- Locked `mujoco` to `>=3.8.1,<3.9` to avoid breaking changes in 3.9.x
+
 # 0.2.0
 
 ## Fixes

--- a/mujoco_usd_converter/_impl/body.py
+++ b/mujoco_usd_converter/_impl/body.py
@@ -45,6 +45,7 @@ def convert_body(parent: Usd.Prim, name: str, body: mujoco.MjsBody, data: Conver
             site_over: Usd.Prim = data.content[Tokens.Physics].OverridePrim(site_prim.GetPath())
             data.references[Tokens.PhysicsSites][site.name] = site_over
             site_over.ApplyAPI("MjcSiteAPI")
+            site_over.ApplyAPI("NewtonSiteAPI")
             set_schema_attribute(site_over, "mjc:group", site.group)
 
     if body != data.spec.worldbody:
@@ -68,6 +69,8 @@ def convert_body(parent: Usd.Prim, name: str, body: mujoco.MjsBody, data: Conver
                 inertia = convert_vec3d(body.inertia)
             else:
                 quat, inertia = extract_inertia(body.fullinertia)
+                body_over.ApplyAPI("NewtonMassAPI")
+                set_schema_attribute(body_over, "newton:inertia", [float(x) for x in body.fullinertia])
             # If the inertia is zero, don't set the principal axes or diagonal inertia
             # In MuJoCo this represents a body with no rotational inertia (typically a static base),
             # and in USD the mass alone is sufficient — the physics engine will handle it

--- a/mujoco_usd_converter/_impl/geom.py
+++ b/mujoco_usd_converter/_impl/geom.py
@@ -12,6 +12,17 @@ from .utils import get_fromto_vectors, set_purpose, set_schema_attribute, set_tr
 __all__ = ["convert_geom", "get_geom_name"]
 
 
+def solref_to_stiffness_damping(solref) -> tuple[float, float]:
+    """Convert MuJoCo solref (timeconst, dampratio) to Newton stiffness and damping."""
+    timeconst = float(solref[0])
+    dampratio = float(solref[1])
+    if timeconst < 0.0 and dampratio < 0.0:
+        return -timeconst, -dampratio
+    if timeconst <= 0.0 or dampratio <= 0.0:
+        return float("-inf"), float("-inf")
+    return 1.0 / (timeconst * timeconst * dampratio * dampratio), 2.0 / timeconst
+
+
 def get_geom_name(geom: mujoco.MjsGeom) -> str:
     if geom.name:
         return geom.name
@@ -323,12 +334,18 @@ def apply_physics(geom_prim: Usd.Prim, geom: mujoco.MjsGeom, data: ConversionDat
         if inertia := get_inertia_token(geom, data):
             geom_over.ApplyAPI("MjcMeshCollisionAPI")
             set_schema_attribute(geom_over, "mjc:inertia", inertia)
+            if inertia == "shell":
+                geom_over.ApplyAPI("NewtonMassAPI")
+                set_schema_attribute(geom_over, "newton:massModel", "shell")
         if maxhullvert := get_maxhullvert(geom, data):
             geom_over.ApplyAPI("MjcMeshCollisionAPI")
             set_schema_attribute(geom_over, "newton:maxHullVertices", maxhullvert)
             set_schema_attribute(geom_over, "mjc:maxhullvert", maxhullvert)
     else:
         set_schema_attribute(geom_over, "mjc:shellinertia", bool(geom.typeinertia == mujoco.mjtGeomInertia.mjINERTIA_SHELL))
+        if geom.typeinertia == mujoco.mjtGeomInertia.mjINERTIA_SHELL:
+            geom_over.ApplyAPI("NewtonMassAPI")
+            set_schema_attribute(geom_over, "newton:massModel", "shell")
 
     if not np.isnan(geom.mass):
         geom_mass: UsdPhysics.MassAPI = UsdPhysics.MassAPI.Apply(geom_over)
@@ -349,14 +366,15 @@ def acquire_physics_material(geom: mujoco.MjsGeom, data: ConversionData) -> UsdS
     sliding_friction = geom.friction[0]
     torsional_friction = geom.friction[1]
     rolling_friction = geom.friction[2]
-    material_hash = Gf.Vec3f(sliding_friction, torsional_friction, rolling_friction)
+    ke, kd = solref_to_stiffness_damping(geom.solref)
+    material_hash = (sliding_friction, torsional_friction, rolling_friction, ke, kd)
 
     # check for an existing physics material with the same values
     physics_scope = data.content[Tokens.Physics].GetDefaultPrim().GetChild(Tokens.Physics)
     for child in physics_scope.GetChildren():
         if child.HasAPI(UsdPhysics.MaterialAPI):
             physics_material: UsdPhysics.MaterialAPI = UsdPhysics.MaterialAPI(child.GetPrim())
-            if Gf.IsClose(material_hash, hash_physics_material(physics_material), 1e-6):
+            if _material_hash_close(material_hash, hash_physics_material(physics_material)):
                 return UsdShade.Material(physics_material)
 
     return create_physics_material(physics_scope, geom, data)
@@ -366,14 +384,16 @@ def create_physics_material(physics_materials: Usd.Prim, geom: mujoco.MjsGeom, d
     sliding_friction = geom.friction[0]
     torsional_friction = geom.friction[1]
     rolling_friction = geom.friction[2]
+    ke, kd = solref_to_stiffness_damping(geom.solref)
 
     name = data.name_cache.getPrimName(physics_materials, "PhysicsMaterial")
     material: UsdShade.Material = usdex.core.definePhysicsMaterial(physics_materials, name, dynamicFriction=sliding_friction)
 
-    # Apply NewtonMaterialAPI and MjcMaterialAPI for torsional and rolling friction
     material.GetPrim().ApplyAPI("NewtonMaterialAPI")
     set_schema_attribute(material.GetPrim(), "newton:torsionalFriction", torsional_friction)
     set_schema_attribute(material.GetPrim(), "newton:rollingFriction", rolling_friction)
+    set_schema_attribute(material.GetPrim(), "newton:contactStiffness", ke)
+    set_schema_attribute(material.GetPrim(), "newton:contactDamping", kd)
     material.GetPrim().ApplyAPI("MjcMaterialAPI")
     set_schema_attribute(material.GetPrim(), "mjc:torsionalfriction", torsional_friction)
     set_schema_attribute(material.GetPrim(), "mjc:rollingfriction", rolling_friction)
@@ -381,12 +401,17 @@ def create_physics_material(physics_materials: Usd.Prim, geom: mujoco.MjsGeom, d
     return material
 
 
-def hash_physics_material(material: UsdPhysics.MaterialAPI) -> Gf.Vec3f:
-    # we know that all materials in the physics layer have the values authored, so we can just get them
+def hash_physics_material(material: UsdPhysics.MaterialAPI) -> tuple[float, ...]:
     sliding_friction = material.GetDynamicFrictionAttr().Get()
     torsional_friction = material.GetPrim().GetAttribute("mjc:torsionalfriction").Get()
     rolling_friction = material.GetPrim().GetAttribute("mjc:rollingfriction").Get()
-    return Gf.Vec3f(sliding_friction, torsional_friction, rolling_friction)
+    ke = material.GetPrim().GetAttribute("newton:contactStiffness").Get()
+    kd = material.GetPrim().GetAttribute("newton:contactDamping").Get()
+    return (sliding_friction, torsional_friction, rolling_friction, ke, kd)
+
+
+def _material_hash_close(a: tuple[float, ...], b: tuple[float, ...], tol: float = 1e-6) -> bool:
+    return all(abs(x - y) < tol for x, y in zip(a, b))
 
 
 def get_inertia_token(geom: mujoco.MjsGeom, data: ConversionData) -> str:

--- a/mujoco_usd_converter/_impl/scene.py
+++ b/mujoco_usd_converter/_impl/scene.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import usdex.core
-from pxr import Gf, Tf, Usd, UsdPhysics, Vt
+from pxr import Gf, Usd, UsdPhysics, Vt
 
 from .data import ConversionData, Tokens
 from .numpy import convert_vec3d
@@ -57,6 +57,7 @@ def convert_scene(data: ConversionData):
     set_schema_attribute(scene_prim, "mjc:flag:island", not is_disabled(1 << 18, data))
     set_schema_attribute(scene_prim, "mjc:flag:limit", not is_disabled(1 << 3, data))
     set_schema_attribute(scene_prim, "mjc:flag:midphase", not is_disabled(1 << 14, data))
+    set_schema_attribute(scene_prim, "mjc:flag:multiccd", not is_disabled(1 << 19, data))
     set_schema_attribute(scene_prim, "mjc:flag:nativeccd", not is_disabled(1 << 17, data))
     set_schema_attribute(scene_prim, "mjc:flag:refsafe", not is_disabled(1 << 12, data))
     set_schema_attribute(scene_prim, "mjc:flag:sensor", not is_disabled(1 << 13, data))
@@ -67,16 +68,6 @@ def convert_scene(data: ConversionData):
     set_schema_attribute(scene_prim, "mjc:flag:energy", is_enabled(1 << 1, data))
     set_schema_attribute(scene_prim, "mjc:flag:fwdinv", is_enabled(1 << 2, data))
     set_schema_attribute(scene_prim, "mjc:flag:invdiscrete", is_enabled(1 << 3, data))
-
-    # multiccd should be enabled by default, but the schema was not changed to reflect this
-    # We set it to the data spec value regardless of the schema default
-    # If the default schema value is ever changed to enable multiccd, remove the workaround and use set_schema_attribute
-    attr = scene_prim.GetAttribute("mjc:flag:multiccd")
-    default = attr.Get()
-    if default:
-        Tf.Warn("mjc:flag:multiccd default value is fixed, revert the workaround for the incorrect schema default")
-    attr.Set(is_enabled(1 << 4, data))
-
     set_schema_attribute(scene_prim, "mjc:flag:override", is_enabled(1 << 0, data))
 
     actuator_groups = [i for i in range(31) if data.spec.option.disableactuator & (1 << i)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "mujoco>=3.8.1",
+    "mujoco>=3.8.1,<3.9",
     "usd-exchange>=2.2.2", # locked to USD 25.05
-    "newton-usd-schemas>=0.2.0",
+    "newton-usd-schemas>=0.3.1",
     "numpy-stl>=3.2",
     "tinyobjloader>=2.0.0rc13",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "mujoco>=3.8.0",
+    "mujoco>=3.8.1",
     "usd-exchange>=2.2.2", # locked to USD 25.05
     "newton-usd-schemas>=0.2.0",
     "numpy-stl>=3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.10,<3.13"
 dependencies = [
     "mujoco>=3.8.0",
     "usd-exchange>=2.2.2", # locked to USD 25.05
-    "newton-usd-schemas>=0.1.0",
+    "newton-usd-schemas>=0.2.0",
     "numpy-stl>=3.2",
     "tinyobjloader>=2.0.0rc13",
 ]

--- a/tests/data/physics_materials.xml
+++ b/tests/data/physics_materials.xml
@@ -14,6 +14,6 @@
         <geom name="different_friction" type="capsule" size="0.1 0.2" pos="2 0 0" friction="0.5 0.2 0.1" material="visual_mat_2"/>
 
         <!-- Case 4: Geom with default friction and no visual material. -->
-        <geom name="default_friction" type="sphere" size="0.1" pos="3 0 0" friction="1 0.005 0.0001" />
+        <geom name="default_friction" type="sphere" size="0.1" pos="3 0 0"/>
     </worldbody>
 </mujoco>

--- a/tests/testBodies.py
+++ b/tests/testBodies.py
@@ -53,6 +53,7 @@ class TestBodies(ConverterTestCase):
     def test_explicit_inertia_principal_axes(self):
         principal_prim = self.stage.GetPrimAtPath("/bodies/Geometry/explicit_inertia_principal")
         self.assertTrue(principal_prim.HasAPI(UsdPhysics.MassAPI))
+        self.assertFalse(principal_prim.HasAPI("NewtonMassAPI"))
         mass_api = UsdPhysics.MassAPI(principal_prim)
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 2.0)
         self.assertEqual(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0.1, 0.2, 0.3))
@@ -71,6 +72,12 @@ class TestBodies(ConverterTestCase):
     def test_explicit_inertia_full_matrix(self):
         full_prim = self.stage.GetPrimAtPath("/bodies/Geometry/explicit_inertia_full")
         self.assertTrue(full_prim.HasAPI(UsdPhysics.MassAPI))
+        self.assertTrue(full_prim.HasAPI("NewtonMassAPI"))
+        newton_inertia = full_prim.GetAttribute("newton:inertia").Get()
+        self.assertTrue(newton_inertia is not None)
+        expected = [0.4, 0.3, 0.2, 0.05, 0.02, 0.01]
+        for actual, exp in zip(newton_inertia, expected):
+            self.assertAlmostEqual(actual, exp, places=6)
         mass_api = UsdPhysics.MassAPI(full_prim)
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 3.0)
         self.assertEqual(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0.1, 0.2, 0.3))
@@ -106,6 +113,7 @@ class TestBodies(ConverterTestCase):
         regular_prim: Usd.Prim = self.stage.GetPrimAtPath("/bodies/Geometry/regular_dynamic")
         self.assertTrue(regular_prim.HasAPI(UsdPhysics.RigidBodyAPI))
         self.assertFalse(regular_prim.HasAPI(UsdPhysics.MassAPI))
+        self.assertFalse(regular_prim.HasAPI("NewtonMassAPI"))
         self.assertFalse(regular_prim.HasAttribute("mjc:body:gravcomp"))
 
     def test_gravity_compensated(self):
@@ -117,6 +125,7 @@ class TestBodies(ConverterTestCase):
         zero_inertia_prim: Usd.Prim = self.stage.GetPrimAtPath("/bodies/Geometry/zero_inertia")
         self.assertTrue(zero_inertia_prim.HasAPI(UsdPhysics.RigidBodyAPI))
         self.assertTrue(zero_inertia_prim.HasAPI(UsdPhysics.MassAPI))
+        self.assertFalse(zero_inertia_prim.HasAPI("NewtonMassAPI"))
         mass_api = UsdPhysics.MassAPI(zero_inertia_prim)
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 2.0)
         self.assertEqual(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0.1, 0.2, 0.3))

--- a/tests/testGeom.py
+++ b/tests/testGeom.py
@@ -199,6 +199,9 @@ class TestGeom(ConverterTestCase):
         self.assertTrue(prim.HasAPI("MjcCollisionAPI"))
         self.assertTrue(prim.GetAttribute("mjc:shellinertia").HasAuthoredValue())
         self.assertTrue(prim.GetAttribute("mjc:shellinertia").Get())
+        self.assertTrue(prim.HasAPI("NewtonMassAPI"))
+        self.assertTrue(prim.GetAttribute("newton:massModel").HasAuthoredValue())
+        self.assertEqual(prim.GetAttribute("newton:massModel").Get(), "shell")
 
     def test_mjc_mesh_collision_schema(self):
         prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/all_mesh_collision_properties")
@@ -264,6 +267,9 @@ class TestGeom(ConverterTestCase):
         self.assertTrue(prim.HasAPI("MjcMeshCollisionAPI"))
         self.assertTrue(prim.GetAttribute("mjc:inertia").HasAuthoredValue())
         self.assertEqual(prim.GetAttribute("mjc:inertia").Get(), "shell")
+        self.assertTrue(prim.HasAPI("NewtonMassAPI"))
+        self.assertTrue(prim.GetAttribute("newton:massModel").HasAuthoredValue())
+        self.assertEqual(prim.GetAttribute("newton:massModel").Get(), "shell")
         self.assertFalse(prim.GetAttribute("mjc:maxhullvert").HasAuthoredValue())
         self.assertEqual(prim.GetAttribute("mjc:maxhullvert").Get(), -1)
         self.assertFalse(prim.GetAttribute("mjc:shellinertia").HasAuthoredValue())
@@ -295,6 +301,7 @@ class TestGeom(ConverterTestCase):
         prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/default_collider")
         self.assertTrue(prim.HasAPI(UsdPhysics.CollisionAPI))
         self.assertTrue(prim.HasAPI("MjcCollisionAPI"))
+        self.assertFalse(prim.HasAPI("NewtonMassAPI"))
 
         # Check that no MJC properties are authored
         for property in prim.GetPropertiesInNamespace("mjc"):
@@ -327,6 +334,8 @@ class TestGeom(ConverterTestCase):
         self.assertEqual(prim.GetAttribute("mjc:margin").Get(), 0.03)
         self.assertEqual(prim.GetAttribute("mjc:priority").Get(), 2)
         self.assertEqual(prim.GetAttribute("mjc:shellinertia").Get(), True)
+        self.assertTrue(prim.HasAPI("NewtonMassAPI"))
+        self.assertEqual(prim.GetAttribute("newton:massModel").Get(), "shell")
         self.assertEqual(prim.GetAttribute("mjc:solimp").Get(), [0.95, 0.99, 0.001, 0.5, 2.0])
         self.assertEqual(prim.GetAttribute("mjc:solmix").Get(), 0.9)
         self.assertEqual(prim.GetAttribute("mjc:solref").Get(), [0.05, 1.0])

--- a/tests/testPhysicsMaterials.py
+++ b/tests/testPhysicsMaterials.py
@@ -19,13 +19,13 @@ class TestPhysicsMaterials(ConverterTestCase):
         prim1 = stage.GetPrimAtPath("/physics_materials/Geometry/custom_friction_1")
         prim2 = stage.GetPrimAtPath("/physics_materials/Geometry/custom_friction_2")
         prim3 = stage.GetPrimAtPath("/physics_materials/Geometry/different_friction")
-        prim4 = stage.GetPrimAtPath("/physics_materials/Geometry/default_friction")
+        default_friction_prim = stage.GetPrimAtPath("/physics_materials/Geometry/default_friction")
 
         # Get material bindings
         binding_api_1 = UsdShade.MaterialBindingAPI(prim1)
         binding_api_2 = UsdShade.MaterialBindingAPI(prim2)
         binding_api_3 = UsdShade.MaterialBindingAPI(prim3)
-        binding_api_4 = UsdShade.MaterialBindingAPI(prim4)
+        binding_api_4 = UsdShade.MaterialBindingAPI(default_friction_prim)
 
         # Check Physics Bindings
         phys_binding_1 = binding_api_1.GetDirectBinding(materialPurpose="physics")
@@ -64,6 +64,26 @@ class TestPhysicsMaterials(ConverterTestCase):
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:rollingFriction").Get(), 0.05)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("mjc:torsionalfriction").Get(), 0.1)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("mjc:rollingfriction").Get(), 0.05)
+
+        # Assert the default values for the physics material schema on the default_friction geom
+        default_friction_material_prim = stage.GetPrimAtPath(phys_binding_4.GetMaterialPath())
+        self.assertTrue(default_friction_material_prim.IsValid())
+        self.assertTrue(default_friction_material_prim.HasAPI("NewtonMaterialAPI"))
+        # Because NewtonMaterialAPI schema uses floats, the defaults are slightly different from the MuJoCo runtime defaults, so they will be authored
+        self.assertTrue(default_friction_material_prim.GetAttribute("newton:torsionalFriction").HasAuthoredValue())
+        self.assertTrue(default_friction_material_prim.GetAttribute("newton:rollingFriction").HasAuthoredValue())
+        self.assertAlmostEqual(default_friction_material_prim.GetAttribute("newton:torsionalFriction").Get(), 0.005)
+        self.assertAlmostEqual(default_friction_material_prim.GetAttribute("newton:rollingFriction").Get(), 0.0001)
+
+        self.assertTrue(default_friction_material_prim.HasAPI("MjcMaterialAPI"))
+        self.assertFalse(default_friction_material_prim.GetAttribute("mjc:torsionalfriction").HasAuthoredValue())
+        self.assertFalse(default_friction_material_prim.GetAttribute("mjc:rollingfriction").HasAuthoredValue())
+        self.assertAlmostEqual(default_friction_material_prim.GetAttribute("mjc:torsionalfriction").Get(), 0.005)
+        self.assertAlmostEqual(default_friction_material_prim.GetAttribute("mjc:rollingfriction").Get(), 0.0001)
+
+        self.assertTrue(default_friction_material_prim.HasAPI("PhysicsMaterialAPI"))
+        self.assertFalse(default_friction_material_prim.GetAttribute("dynamicFriction").HasAuthoredValue())
+        self.assertAlmostEqual(default_friction_material_prim.GetAttribute("physics:dynamicFriction").Get(), 1.0)
 
         # Assert there are the correct number of materials in the dedicated scope
         physics_scope = stage.GetPrimAtPath("/physics_materials/Physics")

--- a/tests/testPhysicsMaterials.py
+++ b/tests/testPhysicsMaterials.py
@@ -57,11 +57,21 @@ class TestPhysicsMaterials(ConverterTestCase):
         phys_mat_1 = UsdPhysics.MaterialAPI(material_1_prim)
         self.assertEqual(
             set(phys_mat_1.GetPrim().GetAuthoredPropertyNames()),
-            {"physics:dynamicFriction", "newton:rollingFriction", "newton:torsionalFriction", "mjc:rollingfriction", "mjc:torsionalfriction"},
+            {
+                "physics:dynamicFriction",
+                "newton:rollingFriction",
+                "newton:torsionalFriction",
+                "newton:contactStiffness",
+                "newton:contactDamping",
+                "mjc:rollingfriction",
+                "mjc:torsionalfriction",
+            },
         )
         self.assertAlmostEqual(phys_mat_1.GetDynamicFrictionAttr().Get(), 0.8)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:torsionalFriction").Get(), 0.1)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:rollingFriction").Get(), 0.05)
+        self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:contactStiffness").Get(), 2500.0)
+        self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:contactDamping").Get(), 100.0)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("mjc:torsionalfriction").Get(), 0.1)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("mjc:rollingfriction").Get(), 0.05)
 
@@ -74,6 +84,10 @@ class TestPhysicsMaterials(ConverterTestCase):
         self.assertTrue(default_friction_material_prim.GetAttribute("newton:rollingFriction").HasAuthoredValue())
         self.assertAlmostEqual(default_friction_material_prim.GetAttribute("newton:torsionalFriction").Get(), 0.005)
         self.assertAlmostEqual(default_friction_material_prim.GetAttribute("newton:rollingFriction").Get(), 0.0001)
+        self.assertTrue(default_friction_material_prim.GetAttribute("newton:contactStiffness").HasAuthoredValue())
+        self.assertTrue(default_friction_material_prim.GetAttribute("newton:contactDamping").HasAuthoredValue())
+        self.assertAlmostEqual(default_friction_material_prim.GetAttribute("newton:contactStiffness").Get(), 2500.0)
+        self.assertAlmostEqual(default_friction_material_prim.GetAttribute("newton:contactDamping").Get(), 100.0)
 
         self.assertTrue(default_friction_material_prim.HasAPI("MjcMaterialAPI"))
         self.assertFalse(default_friction_material_prim.GetAttribute("mjc:torsionalfriction").HasAuthoredValue())

--- a/tests/testScene.py
+++ b/tests/testScene.py
@@ -157,16 +157,8 @@ class TestScene(ConverterTestCase):
         self.assertTrue(physics_scene.GetGravityMagnitudeAttr().HasAuthoredValue())
         self.assertAlmostEqual(physics_scene.GetGravityMagnitudeAttr().Get(), 9.81, 5)
 
-        # Check that only MJC properties without a default value are authored
-        # Some properties are overridden by the converter to match the data spec (remove this when the schema is updated)
-        overridden_properties = [
-            "mjc:flag:multiccd",
-        ]
         for property in scene.GetPropertiesInNamespace("mjc"):
-            if property.GetName() in overridden_properties:
-                self.assertTrue(property.HasAuthoredValue(), f"Property {property.GetName()} should be authored")
-            else:
-                self.assertFalse(property.HasAuthoredValue(), f"Property {property.GetName()} should not be authored")
+            self.assertFalse(property.HasAuthoredValue(), f"Property {property.GetName()} should not be authored")
 
         # Test that default values are not authored but still available via schema defaults
         # Most flag attributes should not be authored since they match schema defaults
@@ -195,9 +187,7 @@ class TestScene(ConverterTestCase):
 
         for attr_name in default_enabled_flags:
             attr: Usd.Attribute = scene.GetAttribute(attr_name)
-            # Some properties are overridden by the converter to match the data spec (remove this when the schema is updated)
-            if attr_name not in overridden_properties:
-                self.assertEqual(attr.Get(), True, f"Default attribute {attr_name} should still return True via schema default")
+            self.assertEqual(attr.Get(), True, f"Default attribute {attr_name} should still return True via schema default")
 
         default_disabled_flags = [
             "mjc:flag:energy",

--- a/tests/testSites.py
+++ b/tests/testSites.py
@@ -32,6 +32,7 @@ class TestSites(ConverterTestCase):
         self.assertTrue(Gf.IsClose(usdex.core.getLocalTransform(site).GetScale(), Gf.Vec3d(0.1, 0.2, 0.3), 1e-6))
         self.assertEqual(box.GetPurposeAttr().Get(), UsdGeom.Tokens.guide)
         self.assertTrue(site.GetPrim().HasAPI("MjcSiteAPI"))
+        self.assertTrue(site.GetPrim().HasAPI("NewtonSiteAPI"))
         self.assertEqual(site.GetAttribute("mjc:group").Get(), 0)
 
         world_site: Usd.Prim = stage.GetPrimAtPath("/sites/Geometry/worldsite")
@@ -41,6 +42,7 @@ class TestSites(ConverterTestCase):
         self.assertEqual(world_sphere.GetRadiusAttr().Get(), 0.005)
         self.assertEqual(world_sphere.GetPurposeAttr().Get(), UsdGeom.Tokens.guide)
         self.assertTrue(world_site.GetPrim().HasAPI("MjcSiteAPI"))
+        self.assertTrue(world_site.GetPrim().HasAPI("NewtonSiteAPI"))
         self.assertEqual(world_site.GetAttribute("mjc:group").Get(), 1)
 
     def test_sites_in_physics_layer(self):
@@ -77,6 +79,8 @@ class TestSites(ConverterTestCase):
         physics_stage: Usd.Stage = Usd.Stage.Open(physics_layer_path.as_posix())
         site_over: Usd.Prim = physics_stage.GetPrimAtPath("/sites/Geometry/body/site")
         self.assertTrue(site_over.HasAPI("MjcSiteAPI"))
+        self.assertTrue(site_over.HasAPI("NewtonSiteAPI"))
 
         world_site_over: Usd.Prim = physics_stage.GetPrimAtPath("/sites/Geometry/worldsite")
         self.assertTrue(world_site_over.HasAPI("MjcSiteAPI"))
+        self.assertTrue(world_site_over.HasAPI("NewtonSiteAPI"))

--- a/uv.lock
+++ b/uv.lock
@@ -348,7 +348,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mujoco", specifier = ">=3.8.0" },
-    { name = "newton-usd-schemas", specifier = ">=0.1.0" },
+    { name = "newton-usd-schemas", specifier = ">=0.2.0" },
     { name = "numpy-stl", specifier = ">=3.2" },
     { name = "tinyobjloader", specifier = ">=2.0.0rc13" },
     { name = "usd-exchange", specifier = ">=2.2.2" },
@@ -377,11 +377,11 @@ wheels = [
 
 [[package]]
 name = "newton-usd-schemas"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/5e/95a2c4872ca9bc0e6e31344ab7df5f6dceedacc5ea39d5832d352c98cdf4/newton_usd_schemas-0.1.0.tar.gz", hash = "sha256:07420c425abd6282e1e9ac0dce4ef2d87bc6e08639f0b00db694de63684ef341", size = 61275, upload-time = "2026-03-09T19:08:06.437Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/9c/5a40c3fd86975172e01d46872e3f0b2c08409e22bdcac9d75e1e814f2e71/newton_usd_schemas-0.2.0.tar.gz", hash = "sha256:b483a029e54f4a7b06d3156c47860e3e8b77e33e3ee4c4fd525c335d74f898a0", size = 69375, upload-time = "2026-05-07T17:53:51.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/d1/3c16c963f8026e6e813c442db724abc1293fc67442f9620caa0d295a5d7a/newton_usd_schemas-0.1.0-py3-none-any.whl", hash = "sha256:da83ba6a571cf7a3acec449d83477c8273bf37260314aa135a74f85b64256583", size = 12599, upload-time = "2026-03-09T19:08:04.633Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7c/79ff957c828116966894268a749eccf455e4d11f08ef66ea681084c3faaa/newton_usd_schemas-0.2.0-py3-none-any.whl", hash = "sha256:b6402affb6cdc59b0a237994ee5196cc1b43f04f766e527b7e6ef061c0719acf", size = 15551, upload-time = "2026-05-07T17:53:50.13Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 
 [[package]]
 name = "mujoco"
-version = "3.8.0"
+version = "3.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -303,23 +303,23 @@ dependencies = [
     { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyopengl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/d8/9aae1a021b6e15ee69d805d893e01dda71cbaae1c75d5f8ec8e12916cb7c/mujoco-3.8.0.tar.gz", hash = "sha256:250afe57458d6881b2d7659fa0029a128cb57cbbb620268d95647fb9ad742183", size = 918250, upload-time = "2026-04-24T22:59:07.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/ba/ad135f7a4a71360072bc4f202f7ab3130d7d7827cff70ce3e1b382a1a410/mujoco-3.8.1.tar.gz", hash = "sha256:019a0b3406892bc98454eaf55cbd27f85d167758ad785f77c608a61f3a34ad17", size = 922269, upload-time = "2026-05-11T13:44:01.357Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/c0/250652d6ad5bb166d7ce519aad4f8d37b97f75562eb02d2f58afb48447ba/mujoco-3.8.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:e6c7978eb2719b3db3c0ee674feb6d41fb5482f5491fb66e01762f1e7bea4750", size = 7222479, upload-time = "2026-04-24T22:58:12.399Z" },
-    { url = "https://files.pythonhosted.org/packages/99/d8/fb5b7829be742084352942de7ad87751e790587626a7f0767c30a575d63c/mujoco-3.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:956aaaaa78d9402154eaba89a277d1c227bd532811b1eb42b0810573f263e65e", size = 7244062, upload-time = "2026-04-24T22:58:15.245Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/07/a4ca7260159136c0032ee2588ad25175ac156faf4a8cd3a0c66ca886465e/mujoco-3.8.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa2a499277150a562c60e658a97ec1e8e8828b5075fdbe43745835d87e98b62e", size = 6691365, upload-time = "2026-04-24T22:58:17.055Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/09/d06b7a352dd70b3d7c46781082b9ff485b65085d88caefa0bb0df1d4f0d9/mujoco-3.8.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df8b5981d94efd6d99bc8eac7eb322c50d680f306f5e89a260b6d874992ffa7c", size = 7131040, upload-time = "2026-04-24T22:58:19.262Z" },
-    { url = "https://files.pythonhosted.org/packages/11/bc/cd52b2426a030db5bd8ef77d3482ab0a2f0b5c0350cd992f575cc0d4eaba/mujoco-3.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:58f5c499abcf81eb3ab3d5e40dd98b2cc7433e032b81460279f808e517099cf2", size = 5714596, upload-time = "2026-04-24T22:58:21.53Z" },
-    { url = "https://files.pythonhosted.org/packages/83/46/e68d7a05c0c8367e38f5925fc85553df735c379dfbfe0c8adee4833e610b/mujoco-3.8.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:c3579cdbeb2bd157be43e13272953e941acdc59f4a74495a567fa4bc2b4f0166", size = 7235564, upload-time = "2026-04-24T22:58:24.097Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/ae/aeda34f9e07b295be5757ffa006218be341f193138db1e6ee0e7f88a245e/mujoco-3.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d400c0489d8b958eaba361af84d0315a642215e5236485a23460b9636d665730", size = 7255745, upload-time = "2026-04-24T22:58:26.066Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/ae/89c113e77e25e4a5e76c9856c51229ea75d790ffc65f10f0aec794b2e4fe/mujoco-3.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d4297fbd8bce087b52c47c4a4ef4a8e49e9e27db8e419f048c25ebe8d4ba0cb", size = 6705135, upload-time = "2026-04-24T22:58:27.735Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/1f/046931077b28e62a5540f8a942c77fec323b7d5e713d3831d0d55edbe08f/mujoco-3.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c764f37204219506ff0ed7acf7cc3848c65dcf39438cefbe26056b3fd649cd8", size = 7145390, upload-time = "2026-04-24T22:58:29.756Z" },
-    { url = "https://files.pythonhosted.org/packages/26/b4/fbe055a11cc98542a3f0c78051247ae2b34d0ed468cf85feb2c21b7ecde2/mujoco-3.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:0d4521c322a1d1b4925610246548af42031c04ba0ca73956be0fb9fd0465aaa4", size = 5739709, upload-time = "2026-04-24T22:58:31.805Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/0d/35aad24bef1f36e9ebf63367938b16abec82407338d612c37624ff20b0e3/mujoco-3.8.0-cp312-cp312-macosx_10_16_x86_64.whl", hash = "sha256:a495da0cd01aff6ac94ec97f0a1d913e1afe071daf107e220f81814435227982", size = 7265096, upload-time = "2026-04-24T22:58:33.475Z" },
-    { url = "https://files.pythonhosted.org/packages/60/d7/2ee5a123431eb50f234de2759e46f3d0c02876e0b1ffce1b26102ed388e7/mujoco-3.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cc1d25b0cd47248fd39681310950b2bea0f6098f57358c0c02730d365bb80ba1", size = 7204862, upload-time = "2026-04-24T22:58:35.978Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/62/a488e6e0963e0210b8262650d25e51c4c597ff7beed4fe01a7e88e3abfc5/mujoco-3.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:980ab5a2210777cf766e53eb574726f9360e2a87e47d83a6c8d801fb71f2fe52", size = 6743542, upload-time = "2026-04-24T22:58:38.137Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/de/bc2271210dad5c6ab73af294779226308e9cf4ed8bc2dbe59922eb8702ed/mujoco-3.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:323fedd14905b73cfe56ea8ff916716ccf8b57cff348a7aa6932c8983a465d64", size = 7226045, upload-time = "2026-04-24T22:58:41.117Z" },
-    { url = "https://files.pythonhosted.org/packages/65/87/198a88747ff0c01e35070c0c80ae0c05ff8d1a61d6e6f379a4e5ff3e6185/mujoco-3.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:8db22dbc5a6c98241549c8161f20a2b0c2ccc5d08fa42595e7a4b594e35a70dd", size = 5813167, upload-time = "2026-04-24T22:58:43.469Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/68/fb807a3fcd1e19b03879d3af93c0b973e80604c8c9089cff0eab96bff9bd/mujoco-3.8.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:5ca31170eb8b58601c7041397d249d18aeb4c8f417275ddecee8a0ec76c654a6", size = 7314261, upload-time = "2026-05-11T13:43:09.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/84/869c953cb02e7c80a4cc48b3e20ce76ec198526395313d6bbe8820138f87/mujoco-3.8.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ea230ad2240d7709d36f5485fbc13fe494103c8033905d2a341c60eab2c79c29", size = 7281414, upload-time = "2026-05-11T13:43:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a2/1cce351c3544b698046f244e70601a84c576ff6985271add8e899a7f037e/mujoco-3.8.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9865049b44cf2b648ddf88987dd7bc7d805625036b8a8768cc700262a4a7da2d", size = 6730806, upload-time = "2026-05-11T13:43:13.58Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/021bd603d56cf24f088be15a4f250f0980f1cd9b1a207ea8bcfbf094b345/mujoco-3.8.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c2d779d9c47cf53da8399493ca9059e068ccabb60bc4e5dc0c924ade8da6c65", size = 7226603, upload-time = "2026-05-11T13:43:15.976Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/9d710c0b51b549bcbe92976811c17e0383c7c903a6103052863d1015cc23/mujoco-3.8.1-cp310-cp310-win_amd64.whl", hash = "sha256:a42287b7f819888c1963337618c3612390e340e12269969a6274e283116aef30", size = 5799544, upload-time = "2026-05-11T13:43:17.859Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4a/4738b2a3dca4ff636382cc66f796863a55e7909ec987e7863343b56fdcee/mujoco-3.8.1-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:0982269cd4cc6e3377401e7de25e47bedbc0d18764e714900e39e85271a6bee8", size = 7327275, upload-time = "2026-05-11T13:43:20.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f3/80b5fda93084346adc7115ceadeaac4befd2fb1dd0d4fa2a1d6622aad2b1/mujoco-3.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:013071ee0a4984640437644a53f927a3bcce55e5d0be738210102f7fe30f61f7", size = 7292732, upload-time = "2026-05-11T13:43:22.581Z" },
+    { url = "https://files.pythonhosted.org/packages/20/32/2b40e2ee00f8366cc255f79d2248682c58c0a00e7b10ad677a697dca8c08/mujoco-3.8.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63d8757ada42536fa481b1404603c91cb5c30ef1040c52c9cefe623e98ed42cf", size = 6744911, upload-time = "2026-05-11T13:43:24.534Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a0/da51d5b12c2ea07b80f1a01fe2156999d8a7140bcdb36567a9babec34536/mujoco-3.8.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9347b9715ab26512d8bfce652ae554e8a667cf8271ebae840b97296bbfc1d840", size = 7240581, upload-time = "2026-05-11T13:43:27.012Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1b/462d39e79c6caa71ccf0cca8b5e0c0b1c806ac06f2abbefdaf33b992b457/mujoco-3.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:ca6aa25a97d55926bc82c38be6bd7e230935727d7fc0b017bcfe06a60c84aa40", size = 5823659, upload-time = "2026-05-11T13:43:28.954Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4f/ccfaf99fab0042bef61da2cd21d47f41fcff069744b42bc6829d9da6b4fc/mujoco-3.8.1-cp312-cp312-macosx_10_16_x86_64.whl", hash = "sha256:b1c5213eb8fc53ee8c0713391eda5f0766088766025e8b46e1dfd3cb9f00db71", size = 7356297, upload-time = "2026-05-11T13:43:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/33/64e4de2ff6f0ead6c9d204efdd68aea3ca235058829f69b957625768495d/mujoco-3.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06e36128883f484e173d02e6140ae09c1ff9845dbc7fb605b02361d9d2ecaccf", size = 7245562, upload-time = "2026-05-11T13:43:32.736Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a1/597263af3519b1ac1c09bb8fc8f8985e90e4990c8aff62ca1a0c035e824c/mujoco-3.8.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e4e951de3ab2ba5187b4807c648ac551fd6ae27ff04c7e25304b357d35d7fe8", size = 6784316, upload-time = "2026-05-11T13:43:34.837Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2f/8a911be3ed84436bc46b5bdcf4ead6ac9590d0ddc82c006834c49ffd60c4/mujoco-3.8.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2970c90913a52b31eade56f27e5439905f08f1479e7991e257144ca829fa1267", size = 7322546, upload-time = "2026-05-11T13:43:37.074Z" },
+    { url = "https://files.pythonhosted.org/packages/83/58/d580c4abf7dda5231fed0886a626e1815e40c2d118bf7d0052a617435d6e/mujoco-3.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:496b61c863d544e076990d1601555f71e522eb3b7aaae227dfbc5dea522f88a1", size = 5893327, upload-time = "2026-05-11T13:43:39.022Z" },
 ]
 
 [[package]]
@@ -347,7 +347,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mujoco", specifier = ">=3.8.0" },
+    { name = "mujoco", specifier = ">=3.8.1" },
     { name = "newton-usd-schemas", specifier = ">=0.2.0" },
     { name = "numpy-stl", specifier = ">=3.2" },
     { name = "tinyobjloader", specifier = ">=2.0.0rc13" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -347,8 +347,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mujoco", specifier = ">=3.8.1" },
-    { name = "newton-usd-schemas", specifier = ">=0.2.0" },
+    { name = "mujoco", specifier = ">=3.8.1,<3.9" },
+    { name = "newton-usd-schemas", specifier = ">=0.3.1" },
     { name = "numpy-stl", specifier = ">=3.2" },
     { name = "tinyobjloader", specifier = ">=2.0.0rc13" },
     { name = "usd-exchange", specifier = ">=2.2.2" },
@@ -377,11 +377,11 @@ wheels = [
 
 [[package]]
 name = "newton-usd-schemas"
-version = "0.2.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/9c/5a40c3fd86975172e01d46872e3f0b2c08409e22bdcac9d75e1e814f2e71/newton_usd_schemas-0.2.0.tar.gz", hash = "sha256:b483a029e54f4a7b06d3156c47860e3e8b77e33e3ee4c4fd525c335d74f898a0", size = 69375, upload-time = "2026-05-07T17:53:51.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/5d/d48294ea0f60cee4afa8d20757b9a7d2aa7b278da5b70e6070145666b460/newton_usd_schemas-0.3.1.tar.gz", hash = "sha256:18f6c03f23ffff3a4d4f313b02c70d4f925d449da2b378f1f8309cd13eb1a250", size = 66946, upload-time = "2026-06-01T17:48:49.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/7c/79ff957c828116966894268a749eccf455e4d11f08ef66ea681084c3faaa/newton_usd_schemas-0.2.0-py3-none-any.whl", hash = "sha256:b6402affb6cdc59b0a237994ee5196cc1b43f04f766e527b7e6ef061c0719acf", size = 15551, upload-time = "2026-05-07T17:53:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b6/84647196a15dbb51a530a303085b2bb9ef54084a7111755f7a33450193c5/newton_usd_schemas-0.3.1-py3-none-any.whl", hash = "sha256:bc99d8bf8fe0b51fadaca520c5b481b4ceb9c0b14f47665fdf28070d511f9524", size = 18174, upload-time = "2026-06-01T17:48:48.48Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Update `newton-usd-schemas` dependency to `>=0.3.1` and lock `mujoco` to `>=3.8.1,<3.9`
- Author new Newton schema attributes side-by-side with MjcPhysics equivalents:
  - `NewtonSiteAPI` on site prims (presence-only, alongside `MjcSiteAPI`)
  - `NewtonMassAPI` with `newton:inertia` compact tensor on bodies with full inertia matrices (preserves `physics:diagonalInertia`/`principalAxes` as fallback)
  - `NewtonMassAPI` with `newton:massModel = "shell"` on shell inertia collision geoms
  - `newton:contactStiffness` and `newton:contactDamping` on physics materials (computed from MuJoCo `solref` using standard/direct mode conversion)
- Material deduplication hash now includes ke/kd to correctly separate materials with different solref values

## Test plan

- [x] All 176 existing tests pass
- [x] Lint clean (`uv run poe lint`)
- [ ] Manual review of converted USD assets for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)