### PR TITLE
Update to newton-usd-schemas 0.3.1 and lock mujoco to 3.8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Unreleased
+
+## Features
+
+- Apply `NewtonSiteAPI` on site prims alongside `MjcSiteAPI`
+- Apply `NewtonMassAPI` with `newton:massModel = "shell"` on collision geoms with shell inertia
+- Author `newton:inertia` compact tensor on bodies with full inertia matrices
+- Author `newton:contactStiffness` and `newton:contactDamping` on physics materials (computed from MuJoCo solref)
+
+## Dependencies
+
+- Updated to `newton-usd-schemas>=0.3.1`
+- Locked `mujoco` to `>=3.8.1,<3.9` to avoid breaking changes in 3.9.x
+
 # 0.2.0
 
 ## Fixes

--- a/mujoco_usd_converter/_impl/body.py
+++ b/mujoco_usd_converter/_impl/body.py
@@ -4,7 +4,7 @@
 import mujoco
 import numpy as np
 import usdex.core
-from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics
+from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics, Vt
 
 from .data import ConversionData, Tokens
 from .geom import convert_geom, get_geom_name
@@ -45,6 +45,7 @@ def convert_body(parent: Usd.Prim, name: str, body: mujoco.MjsBody, data: Conver
             site_over: Usd.Prim = data.content[Tokens.Physics].OverridePrim(site_prim.GetPath())
             data.references[Tokens.PhysicsSites][site.name] = site_over
             site_over.ApplyAPI("MjcSiteAPI")
+            site_over.ApplyAPI("NewtonSiteAPI")
             set_schema_attribute(site_over, "mjc:group", site.group)
 
     if body != data.spec.worldbody:
@@ -72,8 +73,12 @@ def convert_body(parent: Usd.Prim, name: str, body: mujoco.MjsBody, data: Conver
             # In MuJoCo this represents a body with no rotational inertia (typically a static base),
             # and in USD the mass alone is sufficient — the physics engine will handle it
             if inertia != Gf.Vec3f(0, 0, 0):
+                # Decomposed path kept as fallback for apps that don't support newton:inertia
                 mass_api.CreatePrincipalAxesAttr().Set(quat)
                 mass_api.CreateDiagonalInertiaAttr().Set(inertia)
+                if not np.isnan(body.fullinertia[0]):
+                    body_over.ApplyAPI("NewtonMassAPI")
+                    set_schema_attribute(body_over, "newton:inertia", Vt.DoubleArray.FromNumpy(body.fullinertia))
 
         convert_joints(parent=body_over, body=body, data=data)
 

--- a/mujoco_usd_converter/_impl/geom.py
+++ b/mujoco_usd_converter/_impl/geom.py
@@ -12,6 +12,17 @@ from .utils import get_fromto_vectors, set_purpose, set_schema_attribute, set_tr
 __all__ = ["convert_geom", "get_geom_name"]
 
 
+def solref_to_stiffness_damping(solref) -> tuple[float, float]:
+    """Convert MuJoCo solref (timeconst, dampratio) to Newton stiffness and damping."""
+    timeconst = float(solref[0])
+    dampratio = float(solref[1])
+    if timeconst < 0.0 and dampratio < 0.0:
+        return -timeconst, -dampratio
+    if timeconst <= 0.0 or dampratio <= 0.0:
+        return float("-inf"), float("-inf")
+    return 1.0 / (timeconst * timeconst * dampratio * dampratio), 2.0 / timeconst
+
+
 def get_geom_name(geom: mujoco.MjsGeom) -> str:
     if geom.name:
         return geom.name
@@ -323,12 +334,18 @@ def apply_physics(geom_prim: Usd.Prim, geom: mujoco.MjsGeom, data: ConversionDat
         if inertia := get_inertia_token(geom, data):
             geom_over.ApplyAPI("MjcMeshCollisionAPI")
             set_schema_attribute(geom_over, "mjc:inertia", inertia)
+            if inertia == "shell":
+                geom_over.ApplyAPI("NewtonMassAPI")
+                set_schema_attribute(geom_over, "newton:massModel", "shell")
         if maxhullvert := get_maxhullvert(geom, data):
             geom_over.ApplyAPI("MjcMeshCollisionAPI")
             set_schema_attribute(geom_over, "newton:maxHullVertices", maxhullvert)
             set_schema_attribute(geom_over, "mjc:maxhullvert", maxhullvert)
     else:
         set_schema_attribute(geom_over, "mjc:shellinertia", bool(geom.typeinertia == mujoco.mjtGeomInertia.mjINERTIA_SHELL))
+        if geom.typeinertia == mujoco.mjtGeomInertia.mjINERTIA_SHELL:
+            geom_over.ApplyAPI("NewtonMassAPI")
+            set_schema_attribute(geom_over, "newton:massModel", "shell")
 
     if not np.isnan(geom.mass):
         geom_mass: UsdPhysics.MassAPI = UsdPhysics.MassAPI.Apply(geom_over)
@@ -349,14 +366,15 @@ def acquire_physics_material(geom: mujoco.MjsGeom, data: ConversionData) -> UsdS
     sliding_friction = geom.friction[0]
     torsional_friction = geom.friction[1]
     rolling_friction = geom.friction[2]
-    material_hash = Gf.Vec3f(sliding_friction, torsional_friction, rolling_friction)
+    ke, kd = solref_to_stiffness_damping(geom.solref)
+    material_hash = (sliding_friction, torsional_friction, rolling_friction, ke, kd)
 
     # check for an existing physics material with the same values
     physics_scope = data.content[Tokens.Physics].GetDefaultPrim().GetChild(Tokens.Physics)
     for child in physics_scope.GetChildren():
         if child.HasAPI(UsdPhysics.MaterialAPI):
             physics_material: UsdPhysics.MaterialAPI = UsdPhysics.MaterialAPI(child.GetPrim())
-            if Gf.IsClose(material_hash, hash_physics_material(physics_material), 1e-6):
+            if _material_hash_close(material_hash, hash_physics_material(physics_material)):
                 return UsdShade.Material(physics_material)
 
     return create_physics_material(physics_scope, geom, data)
@@ -366,14 +384,16 @@ def create_physics_material(physics_materials: Usd.Prim, geom: mujoco.MjsGeom, d
     sliding_friction = geom.friction[0]
     torsional_friction = geom.friction[1]
     rolling_friction = geom.friction[2]
+    ke, kd = solref_to_stiffness_damping(geom.solref)
 
     name = data.name_cache.getPrimName(physics_materials, "PhysicsMaterial")
     material: UsdShade.Material = usdex.core.definePhysicsMaterial(physics_materials, name, dynamicFriction=sliding_friction)
 
-    # Apply NewtonMaterialAPI and MjcMaterialAPI for torsional and rolling friction
     material.GetPrim().ApplyAPI("NewtonMaterialAPI")
     set_schema_attribute(material.GetPrim(), "newton:torsionalFriction", torsional_friction)
     set_schema_attribute(material.GetPrim(), "newton:rollingFriction", rolling_friction)
+    set_schema_attribute(material.GetPrim(), "newton:contactStiffness", ke)
+    set_schema_attribute(material.GetPrim(), "newton:contactDamping", kd)
     material.GetPrim().ApplyAPI("MjcMaterialAPI")
     set_schema_attribute(material.GetPrim(), "mjc:torsionalfriction", torsional_friction)
     set_schema_attribute(material.GetPrim(), "mjc:rollingfriction", rolling_friction)
@@ -381,12 +401,17 @@ def create_physics_material(physics_materials: Usd.Prim, geom: mujoco.MjsGeom, d
     return material
 
 
-def hash_physics_material(material: UsdPhysics.MaterialAPI) -> Gf.Vec3f:
-    # we know that all materials in the physics layer have the values authored, so we can just get them
+def hash_physics_material(material: UsdPhysics.MaterialAPI) -> tuple[float, ...]:
     sliding_friction = material.GetDynamicFrictionAttr().Get()
     torsional_friction = material.GetPrim().GetAttribute("mjc:torsionalfriction").Get()
     rolling_friction = material.GetPrim().GetAttribute("mjc:rollingfriction").Get()
-    return Gf.Vec3f(sliding_friction, torsional_friction, rolling_friction)
+    ke = material.GetPrim().GetAttribute("newton:contactStiffness").Get()
+    kd = material.GetPrim().GetAttribute("newton:contactDamping").Get()
+    return (sliding_friction, torsional_friction, rolling_friction, ke, kd)
+
+
+def _material_hash_close(a: tuple[float, ...], b: tuple[float, ...], tol: float = 1e-6) -> bool:
+    return all(abs(x - y) < tol for x, y in zip(a, b))
 
 
 def get_inertia_token(geom: mujoco.MjsGeom, data: ConversionData) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "mujoco>=3.8.1",
+    "mujoco>=3.8.1,<3.9",
     "usd-exchange>=2.2.2", # locked to USD 25.05
-    "newton-usd-schemas>=0.2.0",
+    "newton-usd-schemas>=0.3.1",
     "numpy-stl>=3.2",
     "tinyobjloader>=2.0.0rc13",
 ]

--- a/tests/testBodies.py
+++ b/tests/testBodies.py
@@ -53,6 +53,7 @@ class TestBodies(ConverterTestCase):
     def test_explicit_inertia_principal_axes(self):
         principal_prim = self.stage.GetPrimAtPath("/bodies/Geometry/explicit_inertia_principal")
         self.assertTrue(principal_prim.HasAPI(UsdPhysics.MassAPI))
+        self.assertFalse(principal_prim.HasAPI("NewtonMassAPI"))
         mass_api = UsdPhysics.MassAPI(principal_prim)
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 2.0)
         self.assertEqual(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0.1, 0.2, 0.3))
@@ -71,6 +72,12 @@ class TestBodies(ConverterTestCase):
     def test_explicit_inertia_full_matrix(self):
         full_prim = self.stage.GetPrimAtPath("/bodies/Geometry/explicit_inertia_full")
         self.assertTrue(full_prim.HasAPI(UsdPhysics.MassAPI))
+        self.assertTrue(full_prim.HasAPI("NewtonMassAPI"))
+        newton_inertia = full_prim.GetAttribute("newton:inertia").Get()
+        self.assertTrue(newton_inertia is not None)
+        expected = [0.4, 0.3, 0.2, 0.05, 0.02, 0.01]
+        for actual, exp in zip(newton_inertia, expected):
+            self.assertAlmostEqual(actual, exp, places=6)
         mass_api = UsdPhysics.MassAPI(full_prim)
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 3.0)
         self.assertEqual(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0.1, 0.2, 0.3))
@@ -106,6 +113,7 @@ class TestBodies(ConverterTestCase):
         regular_prim: Usd.Prim = self.stage.GetPrimAtPath("/bodies/Geometry/regular_dynamic")
         self.assertTrue(regular_prim.HasAPI(UsdPhysics.RigidBodyAPI))
         self.assertFalse(regular_prim.HasAPI(UsdPhysics.MassAPI))
+        self.assertFalse(regular_prim.HasAPI("NewtonMassAPI"))
         self.assertFalse(regular_prim.HasAttribute("mjc:body:gravcomp"))
 
     def test_gravity_compensated(self):
@@ -117,6 +125,7 @@ class TestBodies(ConverterTestCase):
         zero_inertia_prim: Usd.Prim = self.stage.GetPrimAtPath("/bodies/Geometry/zero_inertia")
         self.assertTrue(zero_inertia_prim.HasAPI(UsdPhysics.RigidBodyAPI))
         self.assertTrue(zero_inertia_prim.HasAPI(UsdPhysics.MassAPI))
+        self.assertFalse(zero_inertia_prim.HasAPI("NewtonMassAPI"))
         mass_api = UsdPhysics.MassAPI(zero_inertia_prim)
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 2.0)
         self.assertEqual(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0.1, 0.2, 0.3))

--- a/tests/testGeom.py
+++ b/tests/testGeom.py
@@ -199,6 +199,9 @@ class TestGeom(ConverterTestCase):
         self.assertTrue(prim.HasAPI("MjcCollisionAPI"))
         self.assertTrue(prim.GetAttribute("mjc:shellinertia").HasAuthoredValue())
         self.assertTrue(prim.GetAttribute("mjc:shellinertia").Get())
+        self.assertTrue(prim.HasAPI("NewtonMassAPI"))
+        self.assertTrue(prim.GetAttribute("newton:massModel").HasAuthoredValue())
+        self.assertEqual(prim.GetAttribute("newton:massModel").Get(), "shell")
 
     def test_mjc_mesh_collision_schema(self):
         prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/all_mesh_collision_properties")
@@ -264,6 +267,9 @@ class TestGeom(ConverterTestCase):
         self.assertTrue(prim.HasAPI("MjcMeshCollisionAPI"))
         self.assertTrue(prim.GetAttribute("mjc:inertia").HasAuthoredValue())
         self.assertEqual(prim.GetAttribute("mjc:inertia").Get(), "shell")
+        self.assertTrue(prim.HasAPI("NewtonMassAPI"))
+        self.assertTrue(prim.GetAttribute("newton:massModel").HasAuthoredValue())
+        self.assertEqual(prim.GetAttribute("newton:massModel").Get(), "shell")
         self.assertFalse(prim.GetAttribute("mjc:maxhullvert").HasAuthoredValue())
         self.assertEqual(prim.GetAttribute("mjc:maxhullvert").Get(), -1)
         self.assertFalse(prim.GetAttribute("mjc:shellinertia").HasAuthoredValue())
@@ -295,6 +301,7 @@ class TestGeom(ConverterTestCase):
         prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/default_collider")
         self.assertTrue(prim.HasAPI(UsdPhysics.CollisionAPI))
         self.assertTrue(prim.HasAPI("MjcCollisionAPI"))
+        self.assertFalse(prim.HasAPI("NewtonMassAPI"))
 
         # Check that no MJC properties are authored
         for property in prim.GetPropertiesInNamespace("mjc"):
@@ -327,6 +334,8 @@ class TestGeom(ConverterTestCase):
         self.assertEqual(prim.GetAttribute("mjc:margin").Get(), 0.03)
         self.assertEqual(prim.GetAttribute("mjc:priority").Get(), 2)
         self.assertEqual(prim.GetAttribute("mjc:shellinertia").Get(), True)
+        self.assertTrue(prim.HasAPI("NewtonMassAPI"))
+        self.assertEqual(prim.GetAttribute("newton:massModel").Get(), "shell")
         self.assertEqual(prim.GetAttribute("mjc:solimp").Get(), [0.95, 0.99, 0.001, 0.5, 2.0])
         self.assertEqual(prim.GetAttribute("mjc:solmix").Get(), 0.9)
         self.assertEqual(prim.GetAttribute("mjc:solref").Get(), [0.05, 1.0])

--- a/tests/testPhysicsMaterials.py
+++ b/tests/testPhysicsMaterials.py
@@ -57,11 +57,21 @@ class TestPhysicsMaterials(ConverterTestCase):
         phys_mat_1 = UsdPhysics.MaterialAPI(material_1_prim)
         self.assertEqual(
             set(phys_mat_1.GetPrim().GetAuthoredPropertyNames()),
-            {"physics:dynamicFriction", "newton:rollingFriction", "newton:torsionalFriction", "mjc:rollingfriction", "mjc:torsionalfriction"},
+            {
+                "physics:dynamicFriction",
+                "newton:rollingFriction",
+                "newton:torsionalFriction",
+                "newton:contactStiffness",
+                "newton:contactDamping",
+                "mjc:rollingfriction",
+                "mjc:torsionalfriction",
+            },
         )
         self.assertAlmostEqual(phys_mat_1.GetDynamicFrictionAttr().Get(), 0.8)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:torsionalFriction").Get(), 0.1)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:rollingFriction").Get(), 0.05)
+        self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:contactStiffness").Get(), 2500.0)
+        self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:contactDamping").Get(), 100.0)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("mjc:torsionalfriction").Get(), 0.1)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("mjc:rollingfriction").Get(), 0.05)
 
@@ -74,6 +84,10 @@ class TestPhysicsMaterials(ConverterTestCase):
         self.assertTrue(default_friction_material_prim.GetAttribute("newton:rollingFriction").HasAuthoredValue())
         self.assertAlmostEqual(default_friction_material_prim.GetAttribute("newton:torsionalFriction").Get(), 0.005)
         self.assertAlmostEqual(default_friction_material_prim.GetAttribute("newton:rollingFriction").Get(), 0.0001)
+        self.assertTrue(default_friction_material_prim.GetAttribute("newton:contactStiffness").HasAuthoredValue())
+        self.assertTrue(default_friction_material_prim.GetAttribute("newton:contactDamping").HasAuthoredValue())
+        self.assertAlmostEqual(default_friction_material_prim.GetAttribute("newton:contactStiffness").Get(), 2500.0)
+        self.assertAlmostEqual(default_friction_material_prim.GetAttribute("newton:contactDamping").Get(), 100.0)
 
         self.assertTrue(default_friction_material_prim.HasAPI("MjcMaterialAPI"))
         self.assertFalse(default_friction_material_prim.GetAttribute("mjc:torsionalfriction").HasAuthoredValue())

--- a/tests/testSites.py
+++ b/tests/testSites.py
@@ -32,6 +32,7 @@ class TestSites(ConverterTestCase):
         self.assertTrue(Gf.IsClose(usdex.core.getLocalTransform(site).GetScale(), Gf.Vec3d(0.1, 0.2, 0.3), 1e-6))
         self.assertEqual(box.GetPurposeAttr().Get(), UsdGeom.Tokens.guide)
         self.assertTrue(site.GetPrim().HasAPI("MjcSiteAPI"))
+        self.assertTrue(site.GetPrim().HasAPI("NewtonSiteAPI"))
         self.assertEqual(site.GetAttribute("mjc:group").Get(), 0)
 
         world_site: Usd.Prim = stage.GetPrimAtPath("/sites/Geometry/worldsite")
@@ -41,6 +42,7 @@ class TestSites(ConverterTestCase):
         self.assertEqual(world_sphere.GetRadiusAttr().Get(), 0.005)
         self.assertEqual(world_sphere.GetPurposeAttr().Get(), UsdGeom.Tokens.guide)
         self.assertTrue(world_site.GetPrim().HasAPI("MjcSiteAPI"))
+        self.assertTrue(world_site.GetPrim().HasAPI("NewtonSiteAPI"))
         self.assertEqual(world_site.GetAttribute("mjc:group").Get(), 1)
 
     def test_sites_in_physics_layer(self):
@@ -77,6 +79,8 @@ class TestSites(ConverterTestCase):
         physics_stage: Usd.Stage = Usd.Stage.Open(physics_layer_path.as_posix())
         site_over: Usd.Prim = physics_stage.GetPrimAtPath("/sites/Geometry/body/site")
         self.assertTrue(site_over.HasAPI("MjcSiteAPI"))
+        self.assertTrue(site_over.HasAPI("NewtonSiteAPI"))
 
         world_site_over: Usd.Prim = physics_stage.GetPrimAtPath("/sites/Geometry/worldsite")
         self.assertTrue(world_site_over.HasAPI("MjcSiteAPI"))
+        self.assertTrue(world_site_over.HasAPI("NewtonSiteAPI"))

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -347,8 +347,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mujoco", specifier = ">=3.8.1" },
-    { name = "newton-usd-schemas", specifier = ">=0.2.0" },
+    { name = "mujoco", specifier = ">=3.8.1,<3.9" },
+    { name = "newton-usd-schemas", specifier = ">=0.3.1" },
     { name = "numpy-stl", specifier = ">=3.2" },
     { name = "tinyobjloader", specifier = ">=2.0.0rc13" },
     { name = "usd-exchange", specifier = ">=2.2.2" },
@@ -377,11 +377,11 @@ wheels = [
 
 [[package]]
 name = "newton-usd-schemas"
-version = "0.2.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/9c/5a40c3fd86975172e01d46872e3f0b2c08409e22bdcac9d75e1e814f2e71/newton_usd_schemas-0.2.0.tar.gz", hash = "sha256:b483a029e54f4a7b06d3156c47860e3e8b77e33e3ee4c4fd525c335d74f898a0", size = 69375, upload-time = "2026-05-07T17:53:51.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/5d/d48294ea0f60cee4afa8d20757b9a7d2aa7b278da5b70e6070145666b460/newton_usd_schemas-0.3.1.tar.gz", hash = "sha256:18f6c03f23ffff3a4d4f313b02c70d4f925d449da2b378f1f8309cd13eb1a250", size = 66946, upload-time = "2026-06-01T17:48:49.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/7c/79ff957c828116966894268a749eccf455e4d11f08ef66ea681084c3faaa/newton_usd_schemas-0.2.0-py3-none-any.whl", hash = "sha256:b6402affb6cdc59b0a237994ee5196cc1b43f04f766e527b7e6ef061c0719acf", size = 15551, upload-time = "2026-05-07T17:53:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b6/84647196a15dbb51a530a303085b2bb9ef54084a7111755f7a33450193c5/newton_usd_schemas-0.3.1-py3-none-any.whl", hash = "sha256:bc99d8bf8fe0b51fadaca520c5b481b4ceb9c0b14f47665fdf28070d511f9524", size = 18174, upload-time = "2026-06-01T17:48:48.48Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Update `newton-usd-schemas` dependency to `>=0.3.1` and lock `mujoco` to `>=3.8.1,<3.9`
- Author new Newton schema attributes side-by-side with MjcPhysics equivalents:
  - `NewtonSiteAPI` on site prims (presence-only, alongside `MjcSiteAPI`)
  - `NewtonMassAPI` with `newton:inertia` compact tensor on bodies with full inertia matrices (preserves `physics:diagonalInertia`/`principalAxes` as fallback)
  - `NewtonMassAPI` with `newton:massModel = "shell"` on shell inertia collision geoms
  - `newton:contactStiffness` and `newton:contactDamping` on physics materials (computed from MuJoCo `solref` using standard/direct mode conversion)
- Material deduplication hash now includes ke/kd to correctly separate materials with different solref values

## Test plan

- [x] All 176 existing tests pass
- [x] Lint clean (`uv run poe lint`)
- [ ] Manual review of converted USD assets for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)