### PR TITLE
Author newton:damping per degree for angular joints

### DIFF
--- a/mujoco_usd_converter/_impl/joint.py
+++ b/mujoco_usd_converter/_impl/joint.py
@@ -94,7 +94,7 @@ def apply_mjc_joint_api(prim: Usd.Prim, joint: mujoco.MjsJoint, is_joint_limited
     set_schema_attribute(prim, "mjc:stiffness", joint.stiffness[0])
 
     set_schema_attribute(prim, "newton:armature", joint.armature)
-    set_schema_attribute(prim, "newton:damping", joint.damping[0])
+    set_schema_attribute(prim, "newton:damping", to_newton_angular_gain(joint, joint.damping[0]))
     set_schema_attribute(prim, "newton:friction", joint.frictionloss)
     if is_joint_limited:
         limit_stiffness, limit_damping = get_newton_limit_stiffness_damping(joint)
@@ -102,6 +102,17 @@ def apply_mjc_joint_api(prim: Usd.Prim, joint: mujoco.MjsJoint, is_joint_limited
             set_schema_attribute(prim, "newton:limitStiffness", limit_stiffness)
         if limit_damping is not None:
             set_schema_attribute(prim, "newton:limitDamping", limit_damping)
+
+
+def to_newton_angular_gain(joint: mujoco.MjsJoint, value: float) -> float:
+    """Convert a MuJoCo per-radian gain to the per-degree convention used by NewtonJointAPI.
+
+    MuJoCo authors angular gains (damping, stiffness, limit gains) per radian, while the
+    NewtonJointAPI attributes are per degree. Linear DOFs are unaffected.
+    """
+    if joint.type in (mujoco.mjtJoint.mjJNT_HINGE, mujoco.mjtJoint.mjJNT_BALL):
+        return value * (np.pi / 180.0)
+    return value
 
 
 def get_newton_limit_stiffness_damping(joint: mujoco.MjsJoint) -> tuple[float | None, float | None]:
@@ -117,13 +128,8 @@ def get_newton_limit_stiffness_damping(joint: mujoco.MjsJoint) -> tuple[float | 
         stiffness = 1.0 / (timeconst * timeconst * dampratio * dampratio)
         damping = 2.0 / timeconst
 
-    if joint.type in (mujoco.mjtJoint.mjJNT_HINGE, mujoco.mjtJoint.mjJNT_BALL):
-        # NewtonJointAPI angular limit stiffness/damping are authored per degree.
-        radians_per_degree = np.pi / 180.0
-        stiffness *= radians_per_degree
-        damping *= radians_per_degree
-
-    return stiffness, damping
+    # NewtonJointAPI angular limit stiffness/damping are authored per degree.
+    return to_newton_angular_gain(joint, stiffness), to_newton_angular_gain(joint, damping)
 
 
 def is_limited(joint: mujoco.MjsJoint, data: ConversionData) -> bool:

--- a/tests/data/joint_damping.xml
+++ b/tests/data/joint_damping.xml
@@ -1,0 +1,19 @@
+<mujoco model="joint_damping">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="body1" pos="0 0 0.5">
+      <geom type="box" size="0.05 0.05 0.5"/>
+      <joint name="hinge_joint" type="hinge" axis="1 0 0" damping="0.1"/>
+    </body>
+
+    <body name="body2" pos="0 1 0.5">
+      <geom type="box" size="0.05 0.05 0.5"/>
+      <joint name="ball_joint" type="ball" damping="0.1"/>
+    </body>
+
+    <body name="body3" pos="0 2 0.5">
+      <geom type="box" size="0.05 0.05 0.5"/>
+      <joint name="slide_joint" type="slide" axis="0 1 0" damping="0.1"/>
+    </body>
+  </worldbody>
+</mujoco>

--- a/tests/testJoints.py
+++ b/tests/testJoints.py
@@ -52,6 +52,32 @@ class TestJoints(ConverterTestCase):
             joint = add_joint(f"invalid_joint_{index}", mujoco.mjtJoint.mjJNT_SLIDE, solref_limit)
             self.assertEqual(get_newton_limit_stiffness_damping(joint), (None, None))
 
+    def test_newton_damping_is_per_degree(self):
+        # MuJoCo authors joint damping per radian, but NewtonJointAPI authors it per degree,
+        # so angular DOFs must be scaled while linear DOFs pass through unchanged.
+        model = pathlib.Path("./tests/data/joint_damping.xml")
+        asset: Sdf.AssetPath = mujoco_usd_converter.Converter().convert(model, self.tmpDir())
+        stage: Usd.Stage = Usd.Stage.Open(asset.path)
+        self.assertIsValidUsd(stage)
+
+        radians_per_degree = math.pi / 180.0
+
+        hinge: Usd.Prim = stage.GetPrimAtPath("/joint_damping/Geometry/body1/hinge_joint")
+        self.assertTrue(hinge.IsValid())
+        self.assertAlmostEqual(hinge.GetAttribute("newton:damping").Get(), 0.1 * radians_per_degree, places=6)
+        # the MJC attribute retains the authored per-radian value
+        self.assertAlmostEqual(hinge.GetAttribute("mjc:damping").Get(), 0.1)
+
+        ball: Usd.Prim = stage.GetPrimAtPath("/joint_damping/Geometry/body2/ball_joint")
+        self.assertTrue(ball.IsValid())
+        self.assertAlmostEqual(ball.GetAttribute("newton:damping").Get(), 0.1 * radians_per_degree, places=6)
+        self.assertAlmostEqual(ball.GetAttribute("mjc:damping").Get(), 0.1)
+
+        slide: Usd.Prim = stage.GetPrimAtPath("/joint_damping/Geometry/body3/slide_joint")
+        self.assertTrue(slide.IsValid())
+        self.assertAlmostEqual(slide.GetAttribute("newton:damping").Get(), 0.1)
+        self.assertAlmostEqual(slide.GetAttribute("mjc:damping").Get(), 0.1)
+
     def test_hinge_joints(self):
         model = pathlib.Path("./tests/data/hinge_joints.xml")
         asset: Sdf.AssetPath = mujoco_usd_converter.Converter().convert(model, self.tmpDir())
@@ -517,7 +543,8 @@ class TestJoints(ConverterTestCase):
         self.assertTrue(custom_joint.GetAttribute("newton:armature").HasAuthoredValue())
         self.assertAlmostEqual(custom_joint.GetAttribute("newton:armature").Get(), 0.1)
         self.assertTrue(custom_joint.GetAttribute("newton:damping").HasAuthoredValue())
-        self.assertAlmostEqual(custom_joint.GetAttribute("newton:damping").Get(), 0.5)
+        # custom_joint is a hinge, so the per-radian MJC damping is authored per degree in Newton
+        self.assertAlmostEqual(custom_joint.GetAttribute("newton:damping").Get(), 0.5 * math.pi / 180.0, places=6)
         self.assertTrue(custom_joint.GetAttribute("newton:friction").HasAuthoredValue())
         self.assertAlmostEqual(custom_joint.GetAttribute("newton:friction").Get(), 0.2)
         self.assertFalse(custom_joint.GetAttribute("newton:velocityLimit").HasAuthoredValue())


### PR DESCRIPTION
## Description

`apply_mjc_joint_api()` applied the MuJoCo-radian → Newton-degree conversion to the joint *limit* gains (`newton:limitStiffness` / `newton:limitDamping`) but copied `joint.damping` straight into `newton:damping` unchanged. `newton:damping` is documented as `effort * seconds / degrees` for angular DOFs, so hinge and ball joints were authored ~57.3x too large.

Newton's USD importer then divides the authored `newton:damping` by `DegreesToRadian` for revolute DOFs, while `mjc:damping` feeds the deprecated `mujoco.dof_passive_damping` alias for the same DOF. The two disagree and `SolverMuJoCo` raises at finalize:

```
[Error] [isaacsim.physics.newton.impl.newton_stage] [Newton] Initialization failed:
Model.mujoco.dof_passive_damping conflicts with Model.joint_damping at DOF 6:
0.1 != 5.729578036685597
```

(5.729578 = 0.1 / (pi/180) — exactly one missing conversion.)

### Change

Factored the per-degree conversion out of `get_newton_limit_stiffness_damping()` into a shared `to_newton_angular_gain()` helper, and applied it to `newton:damping` as well. `mjc:damping` is unchanged and still carries the authored per-radian MuJoCo value.

Checked the other Newton joint attributes the converter authors for the same class of bug:
- `newton:armature` — units are `mass * distance^2` (angular) / `mass` (linear), no angular scaling. Correct as-is.
- `newton:friction` — units are `effort`, no angular scaling. Correct as-is.
- `newton:velocityLimit` — per-degree, but the converter never authors it.
- `newton:mimicCoef1` — dimensionless per the schema (it is the scale factor in `joint0 = coef0 + coef1 * joint1`). Nothing to convert.
- `newton:mimicCoef0` — this one is the *offset*, not a multiplier, so it carries the follower joint's position units: the schema documents it as `distance or degrees`. `equality.py` authors MuJoCo's `polycoef[0]` unscaled, which is radians for a hinge. This does *not* currently misbehave, because Newton's importer reads `newton:mimicCoef0` with no unit conversion and passes it straight to `add_constraint_mimic()` (radians internally), so the two mistakes cancel. It is a schema-conformance mismatch rather than a live bug, and fixing it means deciding which side is wrong. Left out of this PR.

### Verification

Round-tripped a two-joint MJCF (`angle="radian"`, hinge + slide, `damping="0.1"` on both) through the converter and `ModelBuilder.add_usd()` with `SolverMuJoCo.register_custom_attributes()`:

| | before | after |
|---|---|---|
| authored `newton:damping` (hinge) | 0.1 | 0.0017453292 |
| `model.joint_damping` | `[5.729578, 0.1]` | `[0.1, 0.1]` |
| finalize | `ValueError: ... conflicts ... 0.1 != 5.729578036685597` | clean |

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).

